### PR TITLE
Fix #14: account for hyphenated names

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/test | tap-spec"
   },
   "author": "",
   "license": "ISC",
@@ -24,5 +24,9 @@
     "shapefile-stream": "latest",
     "through2": "^0.6.1",
     "trimmer": "^1.0.0"
+  },
+  "devDependencies": {
+    "tape": "3.0.3",
+    "tap-spec": "2.1.2"
   }
 }

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -12,7 +12,7 @@ function capitalize( str ) {
   str = trimmer( str, '*' );
 
   return str.toLowerCase()
-            .replace( /(?:^|\s)\S/g, function(a){
+            .replace( /(?:^|\s|-)\S/g, function(a){
               return a.toUpperCase();
             })
             .trim();
@@ -107,3 +107,4 @@ function generateMapper( props, type ){
 }
 
 module.exports = generateMapper;
+module.exports.capitalize = capitalize;

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,23 @@
+/**
+ * @file The importer's unit-tests.
+ */
+
+'use strict';
+
+var mapper = require( '../src/mapper' );
+var tape = require( 'tape' );
+
+tape( 'capitalize() correctly normalizes strings.', function ( test ){
+  var testCases = [
+    [ 'multi word name', 'Multi Word Name' ],
+    [ '***multi word name', 'Multi Word Name' ],
+    [ 'hyphenated-name', 'Hyphenated-Name' ]
+  ];
+  test.plan( testCases.length );
+  testCases.forEach( function ( testCase ){
+    test.equal(
+      mapper.capitalize( testCase[ 0 ] ), testCase[ 1 ],
+      'Capitalized/normalized name matches expected.'
+    );
+  });
+});


### PR DESCRIPTION
Add a hyphen to the regex in `src.mapper.capitalize()`, closing #14. Also add a unit-test.